### PR TITLE
jj-fzf: ensure that sub-shell is bash

### DIFF
--- a/jj-fzf
+++ b/jj-fzf
@@ -3,6 +3,8 @@
 set -Eeuo pipefail #-x
 SCRIPTNAME=`basename $0` && function die  { [ -n "$*" ] && echo "$SCRIPTNAME: **ERROR**: ${*:-aborting}" >&2; exit 127 ; }
 SELF="$0"
+# for function exports to work sub-shell must be bash too
+export SHELL=bash
 
 # == PREVIEW fast path ==
 export REVPAT='^[^a-z()0-9]*([k-xyz]{7,})([?]*)\ '		# line start, ignore --graph, parse revision letters, catch '??'-postfix


### PR DESCRIPTION
`jj-fzf` exports some bash functions, and tells `fzf` to run them. But this only works if both `jj-fzf` and the shell that `fzf` spawns are `bash`.

Without this change if your login shell ($SHELL) is not bash, then some commands would fail, e.g. with:
`zsh: command not found: reparenting_revs`