### PR TITLE
Added flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1731245184,
+        "narHash": "sha256-vmLS8+x+gHRv1yzj3n+GTAEObwmhxmkkukB2DwtJRdU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "aebe249544837ce42588aa4b2e7972222ba12e8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = inputs:
+    let forEachSystem = inputs.nixpkgs.lib.genAttrs inputs.nixpkgs.lib.systems.flakeExposed;
+    in {
+      packages = forEachSystem (system:
+        let pkgs = import inputs.nixpkgs { inherit system; };
+            jj-fzf = pkgs.writeShellApplication {
+              name = "jj-fzf";
+              runtimeInputs = with pkgs; [ jujutsu fzf gawk gnused ];
+              text = ''
+                ${./jj-fzf} "$@"
+              '';
+            };
+        in {
+          inherit jj-fzf;
+          default = jj-fzf;
+        }
+      );
+    };
+}


### PR DESCRIPTION
This adds a flake.nix file so `jj-fzf` can be installed with its deps with Nix, just like `jj`.

It uses jj v0.23.0 from nixpkgs.