### PR TITLE
Adjust Makefile to work with macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 # This Source Code Form is licensed MPL-2.0: http://mozilla.org/MPL/2.0
 
-SHELL	::= /bin/bash -o pipefail
+SHELL	:= /bin/bash -o pipefail
 prefix	 ?= /usr/local
 bindir	 ?= ${prefix}/bin
-INSTALL	::= install -c
-RM	::= rm -f
-Q	::= $(if $(findstring 1, $(V)),, @)
+INSTALL	:= install -c
+RM	:= rm -f
+Q	:= $(if $(findstring 1, $(V)),, @)
 
 all: check
 
@@ -13,7 +13,7 @@ check-deps: jj-fzf
 	$Q ./jj-fzf --version
 	$Q ./jj-fzf --help >/dev/null # check-deps
 install: check-deps
-	$(INSTALL) -t "$(bindir)" jj-fzf
+	$(INSTALL) jj-fzf "$(bindir)"
 uninstall:
 	$(RM) "$(bindir)/jj-fzf"
 


### PR DESCRIPTION
This PR makes two small tweaks to the Makefile for a slightly smoother experience on macOS:

- macOS ships with GNU make, not BSD make, but it doesn't ship any GPLv3 GNU tools. That means that it's stuck on GNU Make 3.81. While `::=` and `:=` are defined as equivalent in the GNU Make manual, GNU Make 3.81 only supports the form `:=`. This saves users from having to install `gmake` from homebrew.
- macOS uses BSD `install`, and BSD `install` uses positional args of the form `file1 ... fileN directory` instead of the `-t|--target` flag to specificy `directory`. The fix here is introducing a conditional.